### PR TITLE
adding Axios to `package.json` (fixes #1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.2",
+    "axios": "^0.21.1",
     "web-vitals": "^1.1.0"
   },
   "scripts": {


### PR DESCRIPTION
In its current state, `npm install` followed by `npm start` fails due to missing `axios` dependency in `package.json`.